### PR TITLE
Upgrade deprecated validation rule contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 /build/
 .phpunit.result.cache
 .phpunit.cache
+.DS_Store

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require": {
         "php": ">=8.1",
         "illuminate/support": "^10.0",
-        "laravel/pint": "^1.7"
+        "laravel/pint": "^1.7",
+        "spatie/regex": "^3.1"
     },
     "require-dev": {
         "orchestra/testbench": "^8.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
     <report>
       <html outputDirectory="build/coverage"/>
     </report>
@@ -14,4 +11,9 @@
     </testsuite>
   </testsuites>
   <logging/>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Contracts/Rule.php
+++ b/src/Contracts/Rule.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Vdhicts\ValidationRules\Contracts;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+
+interface Rule extends ValidationRule
+{
+    public function passes(mixed $value): bool;
+
+    public function message(): string;
+}

--- a/src/Rules/AbstractRule.php
+++ b/src/Rules/AbstractRule.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Vdhicts\ValidationRules\Rules;
+
+use Closure;
+use Vdhicts\ValidationRules\Contracts\Rule;
+
+abstract class AbstractRule implements Rule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if ($this->passes($value) === false) {
+            $fail($this->message());
+        }
+    }
+}

--- a/src/Rules/BicNumber.php
+++ b/src/Rules/BicNumber.php
@@ -2,24 +2,15 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Spatie\Regex\Regex;
 
-class BicNumber implements Rule
+class BicNumber extends AbstractRule
 {
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
-        return preg_match('/^([a-zA-Z]){4}([a-zA-Z]){2}([0-9a-zA-Z]){2}([0-9a-zA-Z]{3})?$/', $value) != false;
+        return Regex::match('/^([a-zA-Z]){4}([a-zA-Z]){2}([0-9a-zA-Z]){2}([0-9a-zA-Z]{3})?$/', $value)->hasMatch();
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return __('validationRules.bic_number');

--- a/src/Rules/Contains.php
+++ b/src/Rules/Contains.php
@@ -2,22 +2,16 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Str;
 
-class Contains implements Rule
+class Contains extends AbstractRule
 {
-    public function __construct(private readonly string $needle = '')
-    {
+    public function __construct(
+        private readonly string $needle = ''
+    ) {
     }
 
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         if (trim($this->needle) === '') {
             return false;
@@ -26,9 +20,6 @@ class Contains implements Rule
         return Str::contains($value, $this->needle);
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return sprintf(

--- a/src/Rules/ContainsAny.php
+++ b/src/Rules/ContainsAny.php
@@ -2,29 +2,20 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Str;
 
-class ContainsAny implements Rule
+class ContainsAny extends AbstractRule
 {
-    public function __construct(private readonly array $needles)
-    {
+    public function __construct(
+        private readonly array $needles
+    ) {
     }
 
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         return Str::contains($value, $this->needles);
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return sprintf(

--- a/src/Rules/DateAfterOrEqual.php
+++ b/src/Rules/DateAfterOrEqual.php
@@ -3,21 +3,15 @@
 namespace Vdhicts\ValidationRules\Rules;
 
 use DateTimeInterface;
-use Illuminate\Contracts\Validation\Rule;
 
-class DateAfterOrEqual implements Rule
+class DateAfterOrEqual extends AbstractRule
 {
-    public function __construct(private readonly DateTimeInterface $date)
-    {
+    public function __construct(
+        private readonly DateTimeInterface $date
+    ) {
     }
 
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         $limitTimestamp = $this
             ->date
@@ -26,14 +20,11 @@ class DateAfterOrEqual implements Rule
         return strtotime($value) >= $limitTimestamp;
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return sprintf(
             __('validationRules.date_after_or_equal'),
-            $this->date->format(DateTimeInterface::ISO8601)
+            $this->date->format('c')
         );
     }
 }

--- a/src/Rules/DateBeforeOrEqual.php
+++ b/src/Rules/DateBeforeOrEqual.php
@@ -3,21 +3,15 @@
 namespace Vdhicts\ValidationRules\Rules;
 
 use DateTimeInterface;
-use Illuminate\Contracts\Validation\Rule;
 
-class DateBeforeOrEqual implements Rule
+class DateBeforeOrEqual extends AbstractRule
 {
-    public function __construct(private readonly DateTimeInterface $date)
-    {
+    public function __construct(
+        private readonly DateTimeInterface $date
+    ) {
     }
 
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         $limitTimestamp = $this
             ->date
@@ -31,14 +25,11 @@ class DateBeforeOrEqual implements Rule
         return strtotime($value) <= $limitTimestamp;
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return sprintf(
             __('validationRules.date_before_or_equal'),
-            $this->date->format(DateTimeInterface::ISO8601)
+            $this->date->format('c')
         );
     }
 }

--- a/src/Rules/DateHasSpecificMinutes.php
+++ b/src/Rules/DateHasSpecificMinutes.php
@@ -3,35 +3,30 @@
 namespace Vdhicts\ValidationRules\Rules;
 
 use Exception;
-use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Carbon;
 
-class DateHasSpecificMinutes implements Rule
+class DateHasSpecificMinutes extends AbstractRule
 {
-    public function __construct(private readonly array $allowedMinutes, private readonly string $format = 'Y-m-d H:i')
-    {
+    /**
+     * @param int[] $allowedMinutes
+     */
+    public function __construct(
+        private readonly array $allowedMinutes,
+        private readonly string $format = 'Y-m-d H:i'
+    ) {
     }
 
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         try {
             $date = Carbon::createFromFormat($this->format, $value);
-        } catch (Exception $exception) {
+        } catch (Exception) {
             return false;
         }
 
-        return in_array($date->minute, $this->allowedMinutes);
+        return in_array($date->minute, $this->allowedMinutes, true);
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return trans('validationRules.date_has_specific_minutes', [

--- a/src/Rules/DutchPhone.php
+++ b/src/Rules/DutchPhone.php
@@ -2,24 +2,15 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Spatie\Regex\Regex;
 
-class DutchPhone implements Rule
+class DutchPhone extends AbstractRule
 {
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
-        return preg_match('/^(\+|00|0)(31\s?)?(6[\s-]?[1-9][0-9]{7}|[1-9][0-9][\s-]?[1-9][0-9]{6}|[1-9][0-9]{2}[\s-]?[1-9][0-9]{5})$/', $value) != false;
+        return Regex::match('/^(\+|00|0)(31\s?)?(6[\s-]?[1-9][0-9]{7}|[1-9][0-9][\s-]?[1-9][0-9]{6}|[1-9][0-9]{2}[\s-]?[1-9][0-9]{5})$/', $value)->hasMatch();
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return __('validationRules.dutch_phone');

--- a/src/Rules/DutchPostalCode.php
+++ b/src/Rules/DutchPostalCode.php
@@ -2,24 +2,15 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Spatie\Regex\Regex;
 
-class DutchPostalCode implements Rule
+class DutchPostalCode extends AbstractRule
 {
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
-        return preg_match('/^[1-9][0-9]{3} ?(?!sa|sd|ss)[a-z]{2}$/i', $value) != false;
+        return Regex::match('/^[1-9][0-9]{3} ?(?!sa|sd|ss)[a-z]{2}$/i', $value)->hasMatch();
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return __('validationRules.dutch_postal_code');

--- a/src/Rules/HexColor.php
+++ b/src/Rules/HexColor.php
@@ -2,24 +2,18 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Spatie\Regex\Regex;
 
-class HexColor implements Rule
+/**
+ * @deprecated use the builtin `hex_color`, see: https://laravel.com/docs/10.x/validation#rule-hex-color
+ */
+class HexColor extends AbstractRule
 {
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
-        return preg_match('/^#?[a-fA-F0-9]{3,6}$/', $value) != false;
+        return Regex::match('/^#?[a-fA-F0-9]{3,6}$/', $value)->hasMatch();
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return __('validationRules.hex_color');

--- a/src/Rules/Hostname.php
+++ b/src/Rules/Hostname.php
@@ -2,24 +2,15 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Spatie\Regex\Regex;
 
-class Hostname implements Rule
+class Hostname extends AbstractRule
 {
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
-        return preg_match('/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/', $value) != false;
+        return Regex::match('/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/', $value)->hasMatch();
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return __('validationRules.hostname');

--- a/src/Rules/InternationalBankAccountNumber.php
+++ b/src/Rules/InternationalBankAccountNumber.php
@@ -2,24 +2,15 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Spatie\Regex\Regex;
 
-class InternationalBankAccountNumber implements Rule
+class InternationalBankAccountNumber extends AbstractRule
 {
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
-        return preg_match('/[a-zA-Z]{2}[0-9]{2}[a-zA-Z0-9]{4}[0-9]{7}([a-zA-Z0-9]?){0,16}/', $value) != false;
+        return Regex::match('/[a-zA-Z]{2}[0-9]{2}[a-zA-Z0-9]{4}[0-9]{7}([a-zA-Z0-9]?){0,16}/', $value)->hasMatch();
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return __('validationRules.iban');

--- a/src/Rules/Interval.php
+++ b/src/Rules/Interval.php
@@ -4,17 +4,10 @@ namespace Vdhicts\ValidationRules\Rules;
 
 use DateInterval;
 use Exception;
-use Illuminate\Contracts\Validation\Rule;
 
-class Interval implements Rule
+class Interval extends AbstractRule
 {
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         // Empty string means 0 interval
         if ($value === '') {
@@ -24,14 +17,11 @@ class Interval implements Rule
             new DateInterval($value);
 
             return true;
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return trans('validationRules.interval');

--- a/src/Rules/MaximumHourDifference.php
+++ b/src/Rules/MaximumHourDifference.php
@@ -5,25 +5,20 @@ namespace Vdhicts\ValidationRules\Rules;
 use Carbon\Carbon;
 use DateTimeInterface;
 use Exception;
-use Illuminate\Contracts\Validation\Rule;
 
-class MaximumHourDifference implements Rule
+class MaximumHourDifference extends AbstractRule
 {
-    public function __construct(private readonly DateTimeInterface $date, private readonly int $hours = 24)
-    {
+    public function __construct(
+        private readonly DateTimeInterface $date,
+        private readonly int $hours = 24
+    ) {
     }
 
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         try {
             $end = new Carbon($value);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
 
@@ -32,9 +27,6 @@ class MaximumHourDifference implements Rule
         return ($diffInMinutes / 60) <= $this->hours;
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return sprintf(

--- a/src/Rules/MimeType.php
+++ b/src/Rules/MimeType.php
@@ -2,28 +2,19 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Spatie\Regex\Regex;
 
-class MimeType implements Rule
+class MimeType extends AbstractRule
 {
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         if (! is_string($value)) {
             return false;
         }
 
-        return preg_match('/^\w+\/[-+.\w]+$/', $value) === 1;
+        return Regex::match('/^\w+\/[-+.\w]+$/', $value)->hasMatch();
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return trans('validationRules.mime_type');

--- a/src/Rules/NotContains.php
+++ b/src/Rules/NotContains.php
@@ -2,22 +2,16 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Str;
 
-class NotContains implements Rule
+class NotContains extends AbstractRule
 {
-    public function __construct(private readonly string $needle = '')
-    {
+    public function __construct(
+        private readonly string $needle = ''
+    ) {
     }
 
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         if ($this->needle === '') {
             return true;
@@ -26,9 +20,6 @@ class NotContains implements Rule
         return ! Str::contains($value, $this->needle);
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return sprintf(

--- a/src/Rules/Phone.php
+++ b/src/Rules/Phone.php
@@ -2,17 +2,11 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Spatie\Regex\Regex;
 
-class Phone implements Rule
+class Phone extends AbstractRule
 {
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         $validationRegex = sprintf(
             '/^\+?(%1$s)? ?(?(?=\()(\(%2$s\) ?%3$s)|([. -]?(%2$s[. -]*)?%3$s))$/',
@@ -21,12 +15,9 @@ class Phone implements Rule
             '((\d{3,5})[. -]?(\d{4})|(\d{2}[. -]?){4})'
         );
 
-        return preg_match($validationRegex, $value) != false;
+        return Regex::match($validationRegex, $value)->hasMatch();
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return __('validationRules.phone');

--- a/src/Rules/PositiveInterval.php
+++ b/src/Rules/PositiveInterval.php
@@ -4,9 +4,8 @@ namespace Vdhicts\ValidationRules\Rules;
 
 use DateInterval;
 use Exception;
-use Illuminate\Contracts\Validation\Rule;
 
-class PositiveInterval implements Rule
+class PositiveInterval extends AbstractRule
 {
     /**
      * Checks if the date interval is positive.
@@ -20,13 +19,7 @@ class PositiveInterval implements Rule
             $interval->format('P%yY%mM%dDT%hH%iM%sS') !== 'P0Y0M0DT0H0M0S';
     }
 
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         if ($value instanceof DateInterval) {
             return $this->isPositiveInterval($value);
@@ -36,14 +29,11 @@ class PositiveInterval implements Rule
             $dateInterval = new DateInterval($value);
 
             return $this->isPositiveInterval($dateInterval);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return trans('validationRules.positive_interval');

--- a/src/Rules/Price.php
+++ b/src/Rules/Price.php
@@ -2,21 +2,16 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Spatie\Regex\Regex;
 
-class Price implements Rule
+class Price extends AbstractRule
 {
-    public function __construct(private readonly ?string $decimalSign = null)
-    {
+    public function __construct(
+        private readonly ?string $decimalSign = null
+    ) {
     }
 
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         $requiresDecimals = ! is_null($this->decimalSign);
         if (is_null($this->decimalSign)) {
@@ -31,12 +26,9 @@ class Price implements Rule
             $requiresDecimals ? 1 : 0
         );
 
-        return preg_match($pattern, $value) != false;
+        return Regex::match($pattern, $value)->hasMatch();
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         if (is_null($this->decimalSign)) {

--- a/src/Rules/SecureUrl.php
+++ b/src/Rules/SecureUrl.php
@@ -2,28 +2,19 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Spatie\Regex\Regex;
 
-class SecureUrl implements Rule
+class SecureUrl extends AbstractRule
 {
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param string $attribute
-     * @param mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         if (! is_string($value)) {
             return false;
         }
 
-        return preg_match('/^https:\/\/[a-z0-9-]{1,63}(\.[a-z0-9-]{1,63})+(\/\S*)?$/', $value) === 1;
+        return Regex::match('/^https:\/\/[a-z0-9-]{1,63}(\.[a-z0-9-]{1,63})+(\/\S*)?$/', $value)->hasMatch();
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return trans('validationRules.secure_url');

--- a/src/Rules/Semver.php
+++ b/src/Rules/Semver.php
@@ -2,31 +2,25 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Spatie\Regex\Regex;
 
-class Semver implements Rule
+class Semver extends AbstractRule
 {
     /**
      * Determine if the validation rule passes.
      *
-     * @param string $attribute
-     * @param mixed $value
-     *
      * @see https://regex101.com/r/vkijKf/1/
      * @see https://semver.org/
      */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         if (! is_string($value)) {
             return false;
         }
 
-        return preg_match('/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/', $value) === 1;
+        return Regex::match('/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/', $value)->hasMatch();
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return trans('validationRules.semver');

--- a/src/Rules/VatNumber.php
+++ b/src/Rules/VatNumber.php
@@ -2,18 +2,17 @@
 
 namespace Vdhicts\ValidationRules\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Spatie\Regex\Regex;
 
-class VatNumber implements Rule
+class VatNumber extends AbstractRule
 {
     /**
      * Regular expression patterns per country code.
      *
-     * @var array
      *
      * @see http://ec.europa.eu/taxation_customs/vies/faq.html?locale=en#item_11
      */
-    private $vatPatterns = [
+    private array $vatPatterns = [
         'AT' => 'U[A-Z\d]{8}',
         'BE' => '(0\d{9}|\d{10})',
         'BG' => '\d{9,10}',
@@ -44,13 +43,7 @@ class VatNumber implements Rule
         'SK' => '\d{10}',
     ];
 
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string $attribute
-     * @param  mixed $value
-     */
-    public function passes($attribute, $value): bool
+    public function passes(mixed $value): bool
     {
         $vatNumber = strtoupper($value);
 
@@ -61,12 +54,9 @@ class VatNumber implements Rule
 
         $number = str_replace(' ', '', substr($vatNumber, 2));
 
-        return preg_match('/^'.$this->vatPatterns[$country].'$/', $number) != false;
+        return Regex::match('/^'.$this->vatPatterns[$country].'$/', $number)->hasMatch();
     }
 
-    /**
-     * Get the validation error message.
-     */
     public function message(): string
     {
         return __('validationRules.vat_number');

--- a/src/ValidationRulesServiceProvider.php
+++ b/src/ValidationRulesServiceProvider.php
@@ -6,7 +6,7 @@ use Illuminate\Support\ServiceProvider;
 
 class ValidationRulesServiceProvider extends ServiceProvider
 {
-    public function boot()
+    public function boot(): void
     {
         $this->loadTranslationsFrom(__DIR__.'/../resources/lang/', 'validationRules');
 

--- a/tests/Rules/BicNumberTest.php
+++ b/tests/Rules/BicNumberTest.php
@@ -7,7 +7,7 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class BicNumberTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new BicNumber();
         $validValues = [
@@ -20,14 +20,14 @@ class BicNumberTest extends TestCase
             'CEDELULLXXX',
         ];
         foreach ($validValues as $validValue) {
-            $this->assertTrue($rule->passes('', $validValue), $validValue);
+            $this->assertTrue($rule->passes($validValue), $validValue);
         }
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new BicNumber();
-        $this->assertFalse($rule->passes('', 'CE1EL2LLFFF'));
-        $this->assertFalse($rule->passes('', 'E31DCLLFFF'));
+        $this->assertFalse($rule->passes('CE1EL2LLFFF'));
+        $this->assertFalse($rule->passes('E31DCLLFFF'));
     }
 }

--- a/tests/Rules/ContainsAnyTest.php
+++ b/tests/Rules/ContainsAnyTest.php
@@ -7,18 +7,18 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class ContainsAnyTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new ContainsAny(['foo', 'bar']);
-        $this->assertTrue($rule->passes('', 'this is a test to see if foo or bar is in the text'));
+        $this->assertTrue($rule->passes('this is a test to see if foo or bar is in the text'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new ContainsAny(['test']);
-        $this->assertFalse($rule->passes('', 'this is a fail'));
+        $this->assertFalse($rule->passes('this is a fail'));
 
         $rule = new ContainsAny(['']);
-        $this->assertFalse($rule->passes('', 'this is a test'));
+        $this->assertFalse($rule->passes('this is a test'));
     }
 }

--- a/tests/Rules/ContainsTest.php
+++ b/tests/Rules/ContainsTest.php
@@ -7,18 +7,18 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class ContainsTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new Contains('test');
-        $this->assertTrue($rule->passes('', 'this is a test'));
+        $this->assertTrue($rule->passes('this is a test'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new Contains('test');
-        $this->assertFalse($rule->passes('', 'this is a fail'));
+        $this->assertFalse($rule->passes('this is a fail'));
 
         $rule = new Contains('');
-        $this->assertFalse($rule->passes('', 'this is a test'));
+        $this->assertFalse($rule->passes('this is a test'));
     }
 }

--- a/tests/Rules/DateAfterOrEqualTest.php
+++ b/tests/Rules/DateAfterOrEqualTest.php
@@ -8,19 +8,19 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class DateAfterOrEqualTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
-        $date = Carbon::create(2018, 9, 1, 0, 0, 0);
+        $date = Carbon::create(2018, 9);
         $rule = new DateAfterOrEqual($date);
-        $this->assertTrue($rule->passes('', '2018-09-01'));
-        $this->assertTrue($rule->passes('', '2018-09-21'));
+        $this->assertTrue($rule->passes('2018-09-01'));
+        $this->assertTrue($rule->passes('2018-09-21'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
-        $date = Carbon::create(2018, 9, 1);
+        $date = Carbon::create(2018, 9);
         $rule = new DateAfterOrEqual($date);
-        $this->assertFalse($rule->passes('', '2018-08-01'));
-        $this->assertFalse($rule->passes('', 'test'));
+        $this->assertFalse($rule->passes('2018-08-01'));
+        $this->assertFalse($rule->passes('test'));
     }
 }

--- a/tests/Rules/DateBeforeOrEqualTest.php
+++ b/tests/Rules/DateBeforeOrEqualTest.php
@@ -8,19 +8,19 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class DateBeforeOrEqualTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
-        $date = Carbon::create(2018, 9, 1, 0, 0, 0);
+        $date = Carbon::create(2018, 9);
         $rule = new DateBeforeOrEqual($date);
-        $this->assertTrue($rule->passes('', '2018-09-01'));
-        $this->assertTrue($rule->passes('', '2018-08-21'));
+        $this->assertTrue($rule->passes('2018-09-01'));
+        $this->assertTrue($rule->passes('2018-08-21'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
-        $date = Carbon::create(2018, 9, 1);
+        $date = Carbon::create(2018, 9);
         $rule = new DateBeforeOrEqual($date);
-        $this->assertFalse($rule->passes('', '2018-09-22'));
-        $this->assertFalse($rule->passes('', 'test'));
+        $this->assertFalse($rule->passes('2018-09-22'));
+        $this->assertFalse($rule->passes('test'));
     }
 }

--- a/tests/Rules/DateHasSpecificMinutesTest.php
+++ b/tests/Rules/DateHasSpecificMinutesTest.php
@@ -7,29 +7,29 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class DateHasSpecificMinutesTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new DateHasSpecificMinutes([0, 10, 20, 30, 40, 55]);
-        $this->assertTrue($rule->passes('', '2021-09-30 00:00'));
-        $this->assertTrue($rule->passes('', '2021-09-30 01:10'));
-        $this->assertTrue($rule->passes('', '2021-09-30 01:20'));
-        $this->assertTrue($rule->passes('', '2021-09-30 01:30'));
-        $this->assertTrue($rule->passes('', '2021-09-30 01:40'));
-        $this->assertTrue($rule->passes('', '2021-09-30 01:55'));
+        $this->assertTrue($rule->passes('2021-09-30 00:00'));
+        $this->assertTrue($rule->passes('2021-09-30 01:10'));
+        $this->assertTrue($rule->passes('2021-09-30 01:20'));
+        $this->assertTrue($rule->passes('2021-09-30 01:30'));
+        $this->assertTrue($rule->passes('2021-09-30 01:40'));
+        $this->assertTrue($rule->passes('2021-09-30 01:55'));
 
         $rule = new DateHasSpecificMinutes([0, 15, 30, 45], 'd-m-Y H:i');
-        $this->assertTrue($rule->passes('', '30-09-2021 09:30'));
+        $this->assertTrue($rule->passes('30-09-2021 09:30'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new DateHasSpecificMinutes([0, 10, 20, 30, 40, 55]);
-        $this->assertFalse($rule->passes('', 'lol'));
-        $this->assertFalse($rule->passes('', '2021-09-30 01:01'));
-        $this->assertFalse($rule->passes('', '2021-09-30 01:02'));
+        $this->assertFalse($rule->passes('lol'));
+        $this->assertFalse($rule->passes('2021-09-30 01:01'));
+        $this->assertFalse($rule->passes('2021-09-30 01:02'));
 
         $rule = new DateHasSpecificMinutes([0, 15, 30, 45], 'd-m-Y H:i');
-        $this->assertFalse($rule->passes('', 'lol'));
-        $this->assertFalse($rule->passes('', '30-09-2021 09:17'));
+        $this->assertFalse($rule->passes('lol'));
+        $this->assertFalse($rule->passes('30-09-2021 09:17'));
     }
 }

--- a/tests/Rules/DutchPhoneTest.php
+++ b/tests/Rules/DutchPhoneTest.php
@@ -7,20 +7,20 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class DutchPhoneTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new DutchPhone();
-        $this->assertTrue($rule->passes('', '06-12345678'));
-        $this->assertTrue($rule->passes('', '00316-12345678'));
-        $this->assertTrue($rule->passes('', '+316-12345678'));
-        $this->assertTrue($rule->passes('', '070-1234567'));
-        $this->assertTrue($rule->passes('', '003170-1234567'));
-        $this->assertTrue($rule->passes('', '+3170-1234567'));
+        $this->assertTrue($rule->passes('06-12345678'));
+        $this->assertTrue($rule->passes('00316-12345678'));
+        $this->assertTrue($rule->passes('+316-12345678'));
+        $this->assertTrue($rule->passes('070-1234567'));
+        $this->assertTrue($rule->passes('003170-1234567'));
+        $this->assertTrue($rule->passes('+3170-1234567'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new DutchPhone();
-        $this->assertFalse($rule->passes('', 'this 06 is a fail 12345678'));
+        $this->assertFalse($rule->passes('this 06 is a fail 12345678'));
     }
 }

--- a/tests/Rules/DutchPostalCodeTest.php
+++ b/tests/Rules/DutchPostalCodeTest.php
@@ -7,16 +7,16 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class DutchPostalCodeTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new DutchPostalCode();
-        $this->assertTrue($rule->passes('', '1234 AA'));
-        $this->assertTrue($rule->passes('', '1234AA'));
+        $this->assertTrue($rule->passes('1234 AA'));
+        $this->assertTrue($rule->passes('1234AA'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new DutchPostalCode();
-        $this->assertFalse($rule->passes('', 'this 1234 fail AA'));
+        $this->assertFalse($rule->passes('this 1234 fail AA'));
     }
 }

--- a/tests/Rules/HexColorTest.php
+++ b/tests/Rules/HexColorTest.php
@@ -7,18 +7,18 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class HexColorTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new HexColor();
-        $this->assertTrue($rule->passes('', '#fff'));
-        $this->assertTrue($rule->passes('', '#fff000'));
-        $this->assertTrue($rule->passes('', '#000000'));
-        $this->assertTrue($rule->passes('', '#a0a0a0'));
+        $this->assertTrue($rule->passes('#fff'));
+        $this->assertTrue($rule->passes('#fff000'));
+        $this->assertTrue($rule->passes('#000000'));
+        $this->assertTrue($rule->passes('#a0a0a0'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new HexColor();
-        $this->assertFalse($rule->passes('', 'this 06 is a fail 12345678'));
+        $this->assertFalse($rule->passes('this 06 is a fail 12345678'));
     }
 }

--- a/tests/Rules/HostnameTest.php
+++ b/tests/Rules/HostnameTest.php
@@ -7,17 +7,17 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class HostnameTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new Hostname();
-        $this->assertTrue($rule->passes('', 'example.com'));
-        $this->assertTrue($rule->passes('', 'host-name'));
-        $this->assertTrue($rule->passes('', 'www.example.com'));
+        $this->assertTrue($rule->passes('example.com'));
+        $this->assertTrue($rule->passes('host-name'));
+        $this->assertTrue($rule->passes('www.example.com'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new Hostname();
-        $this->assertFalse($rule->passes('', 'I\'m not a valid hostname!'));
+        $this->assertFalse($rule->passes('I\'m not a valid hostname!'));
     }
 }

--- a/tests/Rules/InternationalBankAccountNumberTest.php
+++ b/tests/Rules/InternationalBankAccountNumberTest.php
@@ -7,17 +7,17 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class InternationalBankAccountNumberTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new InternationalBankAccountNumber();
-        $this->assertTrue($rule->passes('', 'GR1601101250000000012300695'));
-        $this->assertTrue($rule->passes('', 'MU17BOMM0101101030300200000MUR'));
-        $this->assertTrue($rule->passes('', 'NL91ABNA0417164300'));
+        $this->assertTrue($rule->passes('GR1601101250000000012300695'));
+        $this->assertTrue($rule->passes('MU17BOMM0101101030300200000MUR'));
+        $this->assertTrue($rule->passes('NL91ABNA0417164300'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new InternationalBankAccountNumber();
-        $this->assertFalse($rule->passes('', '1234 no iban here'));
+        $this->assertFalse($rule->passes('1234 no iban here'));
     }
 }

--- a/tests/Rules/IntervalTest.php
+++ b/tests/Rules/IntervalTest.php
@@ -7,20 +7,20 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class IntervalTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new Interval();
-        $this->assertTrue($rule->passes('', 'PT39S'));
-        $this->assertTrue($rule->passes('', 'PT59S'));
-        $this->assertTrue($rule->passes('', 'PT6S'));
-        $this->assertTrue($rule->passes('', 'PT4M2S'));
-        $this->assertTrue($rule->passes('', ''));
+        $this->assertTrue($rule->passes('PT39S'));
+        $this->assertTrue($rule->passes('PT59S'));
+        $this->assertTrue($rule->passes('PT6S'));
+        $this->assertTrue($rule->passes('PT4M2S'));
+        $this->assertTrue($rule->passes(''));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new Interval();
-        $this->assertFalse($rule->passes('', 'test'));
-        $this->assertFalse($rule->passes('', '123'));
+        $this->assertFalse($rule->passes('test'));
+        $this->assertFalse($rule->passes('123'));
     }
 }

--- a/tests/Rules/MaximumHourDifferenceTest.php
+++ b/tests/Rules/MaximumHourDifferenceTest.php
@@ -8,23 +8,23 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class MaximumHourDifferenceTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
-        $start = Carbon::create(2018, 9, 18, 9, 0, 0);
+        $start = Carbon::create(2018, 9, 18, 9);
 
         $rule = new MaximumHourDifference($start, 10);
-        $this->assertTrue($rule->passes('', Carbon::create(2018, 9, 17, 23, 0, 0)));
-        $this->assertTrue($rule->passes('', Carbon::create(2018, 9, 17, 23, 59, 0)));
-        $this->assertTrue($rule->passes('', Carbon::create(2018, 9, 18, 10, 30, 0)));
+        $this->assertTrue($rule->passes(Carbon::create(2018, 9, 17, 23)));
+        $this->assertTrue($rule->passes(Carbon::create(2018, 9, 17, 23, 59)));
+        $this->assertTrue($rule->passes(Carbon::create(2018, 9, 18, 10, 30)));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
-        $start = Carbon::create(2018, 9, 18, 9, 30, 0);
+        $start = Carbon::create(2018, 9, 18, 9, 30);
 
         $rule = new MaximumHourDifference($start, 4);
-        $this->assertFalse($rule->passes('', Carbon::create(2018, 9, 17, 23, 0, 0)));
-        $this->assertFalse($rule->passes('', Carbon::create(2018, 9, 17, 13, 45, 0)));
-        $this->assertFalse($rule->passes('', 'test'));
+        $this->assertFalse($rule->passes(Carbon::create(2018, 9, 17, 23)));
+        $this->assertFalse($rule->passes(Carbon::create(2018, 9, 17, 13, 45)));
+        $this->assertFalse($rule->passes('test'));
     }
 }

--- a/tests/Rules/MimeTypeTest.php
+++ b/tests/Rules/MimeTypeTest.php
@@ -7,18 +7,18 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class MimeTypeTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new MimeType();
-        $this->assertTrue($rule->passes('', 'image/jpeg'));
-        $this->assertTrue($rule->passes('', 'text/plain'));
-        $this->assertTrue($rule->passes('', 'application/json'));
+        $this->assertTrue($rule->passes('image/jpeg'));
+        $this->assertTrue($rule->passes('text/plain'));
+        $this->assertTrue($rule->passes('application/json'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new MimeType();
-        $this->assertFalse($rule->passes('', 'test'));
-        $this->assertFalse($rule->passes('', '123'));
+        $this->assertFalse($rule->passes('test'));
+        $this->assertFalse($rule->passes('123'));
     }
 }

--- a/tests/Rules/NotContainsTest.php
+++ b/tests/Rules/NotContainsTest.php
@@ -7,20 +7,20 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class NotContainsTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new NotContains('test');
-        $this->assertTrue($rule->passes('', 'this is a great success'));
-        $this->assertTrue($rule->passes('', ''));
+        $this->assertTrue($rule->passes('this is a great success'));
+        $this->assertTrue($rule->passes(''));
 
         $rule = new NotContains('');
-        $this->assertTrue($rule->passes('', 'this is a great success'));
-        $this->assertTrue($rule->passes('', ''));
+        $this->assertTrue($rule->passes('this is a great success'));
+        $this->assertTrue($rule->passes(''));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new NotContains('test');
-        $this->assertFalse($rule->passes('', 'this is a test'));
+        $this->assertFalse($rule->passes('this is a test'));
     }
 }

--- a/tests/Rules/PhoneTest.php
+++ b/tests/Rules/PhoneTest.php
@@ -7,28 +7,28 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class PhoneTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new Phone();
-        $this->assertTrue($rule->passes('', '+5-555-555-5555'));
-        $this->assertTrue($rule->passes('', '+5 555 555 5555'));
-        $this->assertTrue($rule->passes('', '+5(555)555-5555'));
-        $this->assertTrue($rule->passes('', '(555)5555555'));
-        $this->assertTrue($rule->passes('', '+33(1)5555555'));
-        $this->assertTrue($rule->passes('', '+1 (555) 555 5555'));
-        $this->assertTrue($rule->passes('', '06-12345678'));
-        $this->assertTrue($rule->passes('', '00316-12345678'));
-        $this->assertTrue($rule->passes('', '+316-12345678'));
-        $this->assertTrue($rule->passes('', '070-1234567'));
-        $this->assertTrue($rule->passes('', '003170-1234567'));
-        $this->assertTrue($rule->passes('', '+3170-1234567'));
+        $this->assertTrue($rule->passes('+5-555-555-5555'));
+        $this->assertTrue($rule->passes('+5 555 555 5555'));
+        $this->assertTrue($rule->passes('+5(555)555-5555'));
+        $this->assertTrue($rule->passes('(555)5555555'));
+        $this->assertTrue($rule->passes('+33(1)5555555'));
+        $this->assertTrue($rule->passes('+1 (555) 555 5555'));
+        $this->assertTrue($rule->passes('06-12345678'));
+        $this->assertTrue($rule->passes('00316-12345678'));
+        $this->assertTrue($rule->passes('+316-12345678'));
+        $this->assertTrue($rule->passes('070-1234567'));
+        $this->assertTrue($rule->passes('003170-1234567'));
+        $this->assertTrue($rule->passes('+3170-1234567'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new Phone();
-        $this->assertFalse($rule->passes('', '(11- 97777-7777'));
-        $this->assertFalse($rule->passes('', '(555)5555 555'));
-        $this->assertFalse($rule->passes('', 'this 06 is a fail 12345678'));
+        $this->assertFalse($rule->passes('(11- 97777-7777'));
+        $this->assertFalse($rule->passes('(555)5555 555'));
+        $this->assertFalse($rule->passes('this 06 is a fail 12345678'));
     }
 }

--- a/tests/Rules/PositiveIntervalTest.php
+++ b/tests/Rules/PositiveIntervalTest.php
@@ -8,20 +8,20 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class PositiveIntervalTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new PositiveInterval();
-        $this->assertTrue($rule->passes('', 'PT39S'));
-        $this->assertTrue($rule->passes('', 'PT59S'));
-        $this->assertTrue($rule->passes('', 'PT6S'));
-        $this->assertTrue($rule->passes('', 'PT4M2S'));
-        $this->assertTrue($rule->passes('', new DateInterval('P1D')));
+        $this->assertTrue($rule->passes('PT39S'));
+        $this->assertTrue($rule->passes('PT59S'));
+        $this->assertTrue($rule->passes('PT6S'));
+        $this->assertTrue($rule->passes('PT4M2S'));
+        $this->assertTrue($rule->passes(new DateInterval('P1D')));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new PositiveInterval();
-        $this->assertFalse($rule->passes('', '-P1Y'));
-        $this->assertFalse($rule->passes('', 'test'));
+        $this->assertFalse($rule->passes('-P1Y'));
+        $this->assertFalse($rule->passes('test'));
     }
 }

--- a/tests/Rules/PriceTest.php
+++ b/tests/Rules/PriceTest.php
@@ -7,39 +7,39 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class PriceTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new Price();
-        $this->assertTrue($rule->passes('', '10.50'));
-        $this->assertTrue($rule->passes('', '10,50'));
-        $this->assertTrue($rule->passes('', '105'));
-        $this->assertTrue($rule->passes('', ',50'));
-        $this->assertTrue($rule->passes('', '105,-'));
+        $this->assertTrue($rule->passes('10.50'));
+        $this->assertTrue($rule->passes('10,50'));
+        $this->assertTrue($rule->passes('105'));
+        $this->assertTrue($rule->passes(',50'));
+        $this->assertTrue($rule->passes('105,-'));
     }
 
-    public function testRulePassesDecimalSign()
+    public function testRulePassesDecimalSign(): void
     {
         $rule = new Price(',');
-        $this->assertTrue($rule->passes('', '10,50'));
-        $this->assertTrue($rule->passes('', '105,-'));
+        $this->assertTrue($rule->passes('10,50'));
+        $this->assertTrue($rule->passes('105,-'));
 
         $rule = new Price('.');
-        $this->assertTrue($rule->passes('', '10.50'));
-        $this->assertTrue($rule->passes('', '105.-'));
+        $this->assertTrue($rule->passes('10.50'));
+        $this->assertTrue($rule->passes('105.-'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new Price();
-        $this->assertFalse($rule->passes('', 'no price mentioned'));
+        $this->assertFalse($rule->passes('no price mentioned'));
     }
 
-    public function testRuleFailsDecimalsSign()
+    public function testRuleFailsDecimalsSign(): void
     {
         $rule = new Price(',');
-        $this->assertFalse($rule->passes('', '10.50'));
+        $this->assertFalse($rule->passes('10.50'));
 
         $rule = new Price('.');
-        $this->assertFalse($rule->passes('', '10,50'));
+        $this->assertFalse($rule->passes('10,50'));
     }
 }

--- a/tests/Rules/SecureUrlTest.php
+++ b/tests/Rules/SecureUrlTest.php
@@ -7,19 +7,19 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class SecureUrlTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new SecureUrl();
-        $this->assertTrue($rule->passes('attribute', 'https://google.com'));
-        $this->assertTrue($rule->passes('attribute', 'https://www.google.com'));
-        $this->assertTrue($rule->passes('attribute', 'https://www.google.com/test'));
-        $this->assertTrue($rule->passes('attribute', 'https://www.google.com/test?q=query'));
+        $this->assertTrue($rule->passes('https://google.com'));
+        $this->assertTrue($rule->passes('https://www.google.com'));
+        $this->assertTrue($rule->passes('https://www.google.com/test'));
+        $this->assertTrue($rule->passes('https://www.google.com/test?q=query'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new SecureUrl();
-        $this->assertFalse($rule->passes('attribute', 'http://google.com'));
-        $this->assertFalse($rule->passes('attribute', 123));
+        $this->assertFalse($rule->passes('http://google.com'));
+        $this->assertFalse($rule->passes(123));
     }
 }

--- a/tests/Rules/SemverTest.php
+++ b/tests/Rules/SemverTest.php
@@ -7,21 +7,21 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class SemverTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new Semver();
-        $this->assertTrue($rule->passes('', '0.0.1'));
-        $this->assertTrue($rule->passes('', '1.2.3'));
-        $this->assertTrue($rule->passes('', '10.20.30'));
-        $this->assertTrue($rule->passes('', '1.0.0-beta'));
-        $this->assertTrue($rule->passes('', '1.0.0-rc.1+build.1'));
-        $this->assertTrue($rule->passes('', '10.2.3-DEV-SNAPSHOT'));
+        $this->assertTrue($rule->passes('0.0.1'));
+        $this->assertTrue($rule->passes('1.2.3'));
+        $this->assertTrue($rule->passes('10.20.30'));
+        $this->assertTrue($rule->passes('1.0.0-beta'));
+        $this->assertTrue($rule->passes('1.0.0-rc.1+build.1'));
+        $this->assertTrue($rule->passes('10.2.3-DEV-SNAPSHOT'));
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new Semver();
-        $this->assertFalse($rule->passes('', '0.0.1a'));
-        $this->assertFalse($rule->passes('', '1.1'));
+        $this->assertFalse($rule->passes('0.0.1a'));
+        $this->assertFalse($rule->passes('1.1'));
     }
 }

--- a/tests/Rules/VatNumberTest.php
+++ b/tests/Rules/VatNumberTest.php
@@ -7,7 +7,7 @@ use Vdhicts\ValidationRules\Tests\TestCase;
 
 class VatNumberTest extends TestCase
 {
-    public function testRulePasses()
+    public function testRulePasses(): void
     {
         $rule = new VatNumber();
         $validValues = [
@@ -19,13 +19,13 @@ class VatNumberTest extends TestCase
             'SE999999999999', 'SI99999999', 'SK9999999999',
         ];
         foreach ($validValues as $validValue) {
-            $this->assertTrue($rule->passes('', $validValue), $validValue);
+            $this->assertTrue($rule->passes($validValue), $validValue);
         }
     }
 
-    public function testRuleFails()
+    public function testRuleFails(): void
     {
         $rule = new VatNumber();
-        $this->assertFalse($rule->passes('', 'this 06 is a fail 12345678'));
+        $this->assertFalse($rule->passes('this 06 is a fail 12345678'));
     }
 }


### PR DESCRIPTION
# Changes

- Deprecated hex color validation as Laravel provides that out of the box, see: https://laravel.com/docs/10.x/validation#rule-hex-color.
- Upgrade to the new `ValidationRule` contract of Laravel which causes a breaking change. The breaking change is limited to the `$attribute` parameter no longer being provided to the `passes()` method.
- Use https://github.com/spatie/regex for easier regex usage.
