### PR TITLE
Make IBAN validation more strict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.2', '8.3', '8.4' ]
+        php-versions: [ '8.3', '8.4' ]
 
     name: PHP ${{ matrix.php-versions }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "illuminate/support": "^11.0|^12.0|^13.0",
         "spatie/regex": "^3.1"
     },

--- a/src/Rules/InternationalBankAccountNumber.php
+++ b/src/Rules/InternationalBankAccountNumber.php
@@ -12,7 +12,7 @@ class InternationalBankAccountNumber extends AbstractRule
             return false;
         }
 
-        return Regex::match('/[a-zA-Z]{2}[0-9]{2}[a-zA-Z0-9]{4}[0-9]{7}([a-zA-Z0-9]?){0,16}/', $value)->hasMatch();
+        return Regex::match('/^([a-zA-Z]{2}[0-9]{2}[a-zA-Z0-9]{4}[0-9]{7})([a-zA-Z0-9]?){0,16}$/', $value)->hasMatch();
     }
 
     public function message(): string

--- a/tests/Rules/InternationalBankAccountNumberTest.php
+++ b/tests/Rules/InternationalBankAccountNumberTest.php
@@ -25,6 +25,7 @@ class InternationalBankAccountNumberTest extends TestCase
             [123],
             [false],
             [null],
+            ['NL91ABNA0417164300@'],
         ];
     }
 


### PR DESCRIPTION
# Changes

- Fail the validation when a valid IBAN is somewhere in the provided value but has an invalid suffix or prefix.
